### PR TITLE
implementar HomePage con pantalla dividida para Bloc y Cubit

### DIFF
--- a/project_cubit/lib/Presentation/home_page.dart
+++ b/project_cubit/lib/Presentation/home_page.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../blocs/home_bloc.dart';
+import '../blocs/home_state.dart';
+import '../cubit/cubit.dart';
+import '../cubit/cubit_state.dart';
+import 'loading_view.dart';
+import 'succes_view.dart';
+import 'failure_view.dart';
+import 'initial_view.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final manualCubit = context.read<ManualCubit>();
+
+    return Row(
+      children: [
+        // 🔹 Bloc -> Datos del celular
+        Expanded(
+          child: BlocBuilder<ManualBloc, ManualState>(
+            builder: (context, state) {
+              if (state is ManualLoading) return const LoadingView();
+              if (state is ManualSuccess) {
+                return SuccessView(
+                  data: "Marca: ${state.marca}\n"
+                      "Modelo: ${state.modelo}\n"
+                      "Sistema: ${state.sistema}",
+                );
+              }
+              if (state is ManualFailure) return FailureView(message: state.message);
+              return const InitialView();
+            },
+          ),
+        ),
+
+        // 🔹 Cubit -> Instrucciones
+        Expanded(
+          child: BlocBuilder<ManualCubit, ManualCubitState>(
+            builder: (context, state) {
+              if (state is ManualCubitLoading) return const LoadingView();
+              if (state is ManualCubitSuccess) {
+                return SuccessView(data: state.instrucciones.join("\n"));
+              }
+              if (state is ManualCubitFailure) return FailureView(message: state.message);
+              return Center(
+                child: ElevatedButton(
+                  onPressed: () => manualCubit.loadInstrucciones(),
+                  child: const Text("Cargar Instrucciones (Cubit)"),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/project_cubit/lib/main.dart
+++ b/project_cubit/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:project_cubit/presentation/initial_view.dart';
+import 'presentation/home_page.dart';
+import 'blocs/home_bloc.dart';
+import 'blocs/home_event.dart';
+import 'cubit/cubit.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,10 +14,16 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Manual de Usuario',
-      debugShowCheckedModeBanner: false,
-      home: const InitialView(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(create: (_) => ManualBloc()..add(LoadManual())),
+        BlocProvider(create: (_) => ManualCubit()),
+      ],
+      child: MaterialApp(
+        title: 'Manual de Usuario',
+        debugShowCheckedModeBanner: false,
+        home: const HomePage(),
+      ),
     );
   }
 }


### PR DESCRIPTION
- Se creó presentation/home_page.dart
- Arriba: BlocBuilder<MaBloc, ManualState> muestra datos del celular
- Abajo: BlocBuilder<ManualCubit, ManualCubitState> muestra instrucciones
- Manejo de estados (loading, success, failure)